### PR TITLE
refactor: use plain object instead of Map for habitStats

### DIFF
--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -102,7 +102,7 @@ export function Stats() {
           <div className="space-y-3">
             {/* Active Habits */}
             {activeHabits.map((habit) => {
-              const stat = habitStats.get(habit.id);
+              const stat = habitStats[habit.id];
               if (!stat) return null;
               return (
                 <div key={habit.id} className="card">
@@ -146,7 +146,7 @@ export function Stats() {
                 {showInactive && (
                   <div className="space-y-3">
                     {inactiveHabits.map((habit) => {
-                      const stat = habitStats.get(habit.id);
+                      const stat = habitStats[habit.id];
                       if (!stat) return null;
                       const isPaused = !!habit.paused_at && !habit.archived_at;
                       const isArchived = !!habit.archived_at;

--- a/stores/statsStore.ts
+++ b/stores/statsStore.ts
@@ -27,7 +27,7 @@ export interface HabitInfo {
 interface StatsState {
   overview: OverviewStats | null;
   habits: HabitInfo[];
-  habitStats: Map<string, HabitStat>;
+  habitStats: Record<string, HabitStat>;
   isLoading: boolean;
   error: string | null;
 
@@ -37,7 +37,7 @@ interface StatsState {
 export const useStatsStore = create<StatsState>((set, get) => ({
   overview: null,
   habits: [],
-  habitStats: new Map(),
+  habitStats: {},
   isLoading: false,
   error: null,
 
@@ -56,16 +56,11 @@ export const useStatsStore = create<StatsState>((set, get) => ({
       ]);
 
       // Fetch habit stats in a single batch request
-      const statsMap = new Map<string, HabitStat>();
+      let habitStats: Record<string, HabitStat> = {};
       if (habitsData.length > 0) {
         try {
           const habitIds = habitsData.map(h => h.id).join(',');
-          const batchStats = await api.get<Record<string, HabitStat>>(`/stats/batch?habitIds=${habitIds}`);
-
-          // Convert the response object to a Map
-          Object.entries(batchStats).forEach(([habitId, stat]) => {
-            statsMap.set(habitId, stat);
-          });
+          habitStats = await api.get<Record<string, HabitStat>>(`/stats/batch?habitIds=${habitIds}`);
         } catch (e) {
           console.error('Failed to fetch batch stats:', e);
         }
@@ -74,7 +69,7 @@ export const useStatsStore = create<StatsState>((set, get) => ({
       set({
         overview: overviewData,
         habits: habitsData,
-        habitStats: statsMap,
+        habitStats,
         isLoading: false,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary
Refactors `habitStats` from `Map<string, HabitStat>` to `Record<string, HabitStat>` for better ergonomics and code simplicity.

## Changes
- **stores/statsStore.ts**: Changed type from Map to Record, removed unnecessary object-to-Map conversion
- **components/Stats.tsx**: Updated to use direct property access (`habitStats[id]`) instead of `.get(id)`

## Benefits
- ✅ More ergonomic property access syntax
- ✅ Removed unnecessary conversion overhead
- ✅ More idiomatic React/Zustand pattern
- ✅ Better consistency with API response structure

## Testing
- ✅ Build passes with no TypeScript errors
- ✅ All existing functionality preserved

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)