### PR TITLE
refactor: Extract idle refresh threshold to named constant

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,8 @@ import { Settings } from '@/components/Settings';
 
 type Tab = 'today' | 'stats' | 'settings';
 
+const IDLE_REFRESH_THRESHOLD_MS = 30_000;
+
 export default function Home() {
   const { isAuthenticated, isLoading, checkAuth, logout, fetchDevices } = useAuthStore();
   const { fetchHabits } = useHabitStore();
@@ -58,7 +60,7 @@ export default function Home() {
       if (document.visibilityState === 'visible') {
         const now = Date.now();
         // Only refetch if more than 30 seconds since last refresh
-        if (now - lastRefreshRef.current > 30000) {
+        if (now - lastRefreshRef.current > IDLE_REFRESH_THRESHOLD_MS) {
           lastRefreshRef.current = now;
           refetchCurrentTab();
         }


### PR DESCRIPTION
## Summary
- Extracts magic number `30000` to `IDLE_REFRESH_THRESHOLD_MS = 30_000`
- Improves code readability by making the 30-second threshold explicit
- Follows best practices for avoiding magic numbers in code

## Changes
- Added `IDLE_REFRESH_THRESHOLD_MS` constant at the module level in `app/page.tsx`
- Replaced hardcoded `30000` with the named constant in the idle refresh logic

## Test Plan
- [ ] Verify the application builds successfully
- [ ] Test that the idle refresh functionality still works correctly
- [ ] Confirm that data refetches after 30 seconds of inactivity

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)