### PR TITLE
fix: resolve race condition in visibility change handler

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,12 +19,18 @@ export default function Home() {
   const { fetchHabits } = useHabitStore();
   const { fetchStats } = useStatsStore();
   const [activeTab, setActiveTab] = useState<Tab>('today');
+  const activeTabRef = useRef<Tab>(activeTab);
   const lastRefreshRef = useRef<number>(0);
   const prevAuthenticatedRef = useRef<boolean>(false);
 
   useEffect(() => {
     checkAuth();
   }, [checkAuth]);
+
+  // Keep activeTabRef in sync with activeTab
+  useEffect(() => {
+    activeTabRef.current = activeTab;
+  }, [activeTab]);
 
   // Reset to Today tab only when user logs in (false -> true transition)
   useEffect(() => {
@@ -41,7 +47,7 @@ export default function Home() {
   const refetchCurrentTab = useCallback(() => {
     if (!isAuthenticated) return;
 
-    switch (activeTab) {
+    switch (activeTabRef.current) {
       case 'today':
         fetchHabits();
         break;
@@ -53,7 +59,7 @@ export default function Home() {
         fetchDevices();
         break;
     }
-  }, [activeTab, isAuthenticated, fetchHabits, fetchStats, fetchDevices]);
+  }, [isAuthenticated, fetchHabits, fetchStats, fetchDevices]);
 
   // Refetch on visibility change (user returns from idle/background)
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes a race condition in the visibility change handler that could occur when users switch tabs while the page is hidden.

**Changes:**
- Added `activeTabRef` to track the current tab without causing callback recreation
- Removed `activeTab` from `refetchCurrentTab` dependency array to stabilize the callback
- Added effect to keep `activeTabRef` synchronized with `activeTab` state
- Prevents unnecessary removal and re-addition of visibility change event listeners

**Impact:**
- The `refetchCurrentTab` callback is now stable across tab changes
- Visibility change event listener remains attached without frequent re-registration
- Eliminates potential race conditions when page visibility changes while switching tabs

## Technical Details

**Before:** The `refetchCurrentTab` callback depended on `activeTab`, causing it to be recreated every time the user switched tabs. Since this callback was a dependency of the visibility change effect, the event listener was removed and re-added on every tab change, creating a race condition window.

**After:** Using a ref pattern, the callback remains stable while still accessing the current tab value through `activeTabRef.current`.

## Test Plan

- [ ] Verify app builds successfully without errors
- [ ] Test tab switching while page is visible
- [ ] Test tab switching, then minimize/background the page for 30+ seconds, then return
- [ ] Verify data refreshes correctly for the active tab after returning from idle
- [ ] Check that no unnecessary re-renders or event listener thrashing occurs

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)