### PR TITLE
Fix timezone-safe date handling to prevent off-by-one-day errors

### DIFF
--- a/app/api/stats/batch/route.ts
+++ b/app/api/stats/batch/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { query } from '@/lib/db';
 import { requireAuth } from '@/lib/auth';
 import { isWorkingDay, calculateStreak } from '@/lib/stats-utils';
+import { getTodayLocal, formatLocalDate } from '@/lib/date-utils';
 
 export async function GET(request: NextRequest) {
   const auth = await requireAuth();
@@ -62,11 +63,11 @@ export async function GET(request: NextRequest) {
       const d = new Date(today);
       d.setDate(d.getDate() - i);
       if (isWorkingDay(d, holidays, dayOffs)) {
-        workingDays.push(d.toISOString().split('T')[0]);
+        workingDays.push(formatLocalDate(d));
       }
     }
 
-    const todayStr = today.toISOString().split('T')[0];
+    const todayStr = getTodayLocal();
 
     // Group completions by habit
     const completionsByHabit = new Map<string, typeof completions>();

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -5,6 +5,7 @@ import { useHabitStore } from '@/stores/habitStore';
 import { useCalendarStore } from '@/stores/calendarStore';
 import { HabitCard } from '@/components/HabitCard';
 import { DateSelector } from '@/components/DateSelector';
+import { getTodayLocal, formatLocalDate, parseLocalDate } from '@/lib/date-utils';
 
 // Track optimistic completion states for instant filtering
 type OptimisticCompletion = { completed: boolean; value: number };
@@ -37,15 +38,15 @@ export function Dashboard() {
   }, [fetchHolidays, fetchDayOffs, fetchHabits]);
 
   useEffect(() => {
-    const today = new Date(selectedDate);
+    const today = parseLocalDate(selectedDate);
     const startOfWeek = new Date(today);
     startOfWeek.setDate(today.getDate() - today.getDay());
     const endOfWeek = new Date(startOfWeek);
     endOfWeek.setDate(startOfWeek.getDate() + 6);
-    fetchCompletions(startOfWeek.toISOString().split('T')[0], endOfWeek.toISOString().split('T')[0]);
+    fetchCompletions(formatLocalDate(startOfWeek), formatLocalDate(endOfWeek));
   }, [selectedDate, fetchCompletions]);
 
-  const isToday = selectedDate === new Date().toISOString().split('T')[0];
+  const isToday = selectedDate === getTodayLocal();
   const isWorkDay = isWorkingDay(selectedDate);
 
   const habits = getActiveHabits();
@@ -78,7 +79,7 @@ export function Dashboard() {
         <div>
           <h1 className="text-3xl font-bold">{isToday ? "Today's Habits" : 'Habits'}</h1>
           <p className="text-gray-500 mt-1">
-            {new Date(selectedDate).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
+            {parseLocalDate(selectedDate).toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' })}
           </p>
         </div>
         <DateSelector selectedDate={selectedDate} onDateChange={setSelectedDate} />

--- a/components/DateSelector.tsx
+++ b/components/DateSelector.tsx
@@ -1,23 +1,21 @@
 'use client';
 
+import { getTodayLocal, addDays } from '@/lib/date-utils';
+
 interface DateSelectorProps {
   selectedDate: string;
   onDateChange: (date: string) => void;
 }
 
 export function DateSelector({ selectedDate, onDateChange }: DateSelectorProps) {
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayLocal();
 
   const goToPrevDay = () => {
-    const date = new Date(selectedDate);
-    date.setDate(date.getDate() - 1);
-    onDateChange(date.toISOString().split('T')[0]);
+    onDateChange(addDays(selectedDate, -1));
   };
 
   const goToNextDay = () => {
-    const date = new Date(selectedDate);
-    date.setDate(date.getDate() + 1);
-    onDateChange(date.toISOString().split('T')[0]);
+    onDateChange(addDays(selectedDate, 1));
   };
 
   const goToToday = () => {

--- a/components/Settings.tsx
+++ b/components/Settings.tsx
@@ -5,6 +5,7 @@ import { useHabitStore, Habit } from '@/stores/habitStore';
 import { useCalendarStore } from '@/stores/calendarStore';
 import { useAuthStore } from '@/stores/authStore';
 import { AddHabitModal } from '@/components/AddHabitModal';
+import { parseLocalDate } from '@/lib/date-utils';
 
 interface SettingsProps {
   onLogout: () => void;
@@ -158,7 +159,7 @@ export function Settings({ onLogout }: SettingsProps) {
   };
 
   const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleDateString('en-US', {
+    return parseLocalDate(dateStr).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
       year: 'numeric',

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -1,0 +1,71 @@
+/**
+ * Date utilities for timezone-safe date handling.
+ *
+ * These utilities use local timezone instead of UTC to prevent off-by-one-day errors
+ * for users in timezones ahead of UTC (e.g., JST, AEST).
+ */
+
+/**
+ * Formats a Date object to YYYY-MM-DD string in the user's local timezone.
+ * This replaces the problematic .toISOString().split('T')[0] pattern which uses UTC.
+ *
+ * @param date - The Date object to format
+ * @returns Date string in YYYY-MM-DD format (local timezone)
+ *
+ * @example
+ * // In JST timezone at 2:00 AM on Dec 23
+ * formatLocalDate(new Date()) // "2025-12-23" (not "2025-12-22")
+ */
+export function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Gets today's date in YYYY-MM-DD format (local timezone).
+ * Convenience function for the common case of getting "today".
+ *
+ * @returns Today's date string in YYYY-MM-DD format (local timezone)
+ *
+ * @example
+ * getTodayLocal() // "2025-12-23" in user's timezone
+ */
+export function getTodayLocal(): string {
+  return formatLocalDate(new Date());
+}
+
+/**
+ * Parses a YYYY-MM-DD date string into a Date object at local midnight.
+ * This is safer than `new Date(dateStr)` which interprets the string as UTC.
+ *
+ * @param dateStr - Date string in YYYY-MM-DD format
+ * @returns Date object set to local midnight on the specified date
+ *
+ * @example
+ * // In JST timezone (UTC+9)
+ * parseLocalDate("2025-12-23") // 2025-12-23 00:00:00 JST (not UTC)
+ */
+export function parseLocalDate(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+/**
+ * Adds or subtracts days from a date string, returning a new date string.
+ * Handles timezone correctly by working with Date objects in local timezone.
+ *
+ * @param dateStr - Date string in YYYY-MM-DD format
+ * @param days - Number of days to add (positive) or subtract (negative)
+ * @returns New date string in YYYY-MM-DD format (local timezone)
+ *
+ * @example
+ * addDays("2025-12-23", -1) // "2025-12-22"
+ * addDays("2025-12-23", 1)  // "2025-12-24"
+ */
+export function addDays(dateStr: string, days: number): string {
+  const date = parseLocalDate(dateStr);
+  date.setDate(date.getDate() + days);
+  return formatLocalDate(date);
+}

--- a/lib/stats-utils.ts
+++ b/lib/stats-utils.ts
@@ -2,6 +2,8 @@
  * Shared utilities for stats calculation
  */
 
+import { formatLocalDate } from '@/lib/date-utils';
+
 /**
  * Determines if a given date is a working day
  * @param date The date to check
@@ -16,7 +18,7 @@ export function isWorkingDay(
 ): boolean {
   const dayOfWeek = date.getDay();
   if (dayOfWeek === 0 || dayOfWeek === 6) return false;
-  const dateStr = date.toISOString().split('T')[0];
+  const dateStr = formatLocalDate(date);
   return !holidays.has(dateStr) && !dayOffs.has(dateStr);
 }
 

--- a/stores/calendarStore.ts
+++ b/stores/calendarStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { api } from '@/lib/api';
+import { parseLocalDate } from '@/lib/date-utils';
 
 export interface Holiday {
   date: string;
@@ -87,7 +88,7 @@ export const useCalendarStore = create<CalendarState>((set, get) => ({
   },
 
   isWorkingDay: (dateStr) => {
-    const date = new Date(dateStr);
+    const date = parseLocalDate(dateStr);
     const dayOfWeek = date.getDay();
 
     // Weekend

--- a/stores/habitStore.ts
+++ b/stores/habitStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { api } from '@/lib/api';
+import { getTodayLocal } from '@/lib/date-utils';
 
 export type HabitType = 'boolean' | 'count' | 'time';
 
@@ -74,7 +75,7 @@ export const useHabitStore = create<HabitState>((set, get) => ({
   error: null,
   completions: {},
   activeTimers: {},
-  selectedDate: new Date().toISOString().split('T')[0],
+  selectedDate: getTodayLocal(),
 
   // Computed getters
   getActiveHabits: () => {


### PR DESCRIPTION
## Problem
The app was using `.toISOString().split('T')[0]` throughout the codebase (15+ instances across 7 files), which returns UTC dates and causes off-by-one-day errors for users in timezones ahead of UTC.

**Example of the bug:**
- User in JST (UTC+9) at 2:00 AM on December 23rd
- `.toISOString()` returns `"2025-12-22T17:00:00.000Z"` (previous day in UTC)
- `.split('T')[0]` gives `"2025-12-22"` ❌ (should be `"2025-12-23"`)

**Impact:**
- "Today" showed yesterday's habits for UTC+ users near midnight
- Streak calculations used wrong working days
- Date navigation was off by one day
- Completion tracking misaligned with actual dates

## Solution
Created timezone-safe date utilities in `lib/date-utils.ts`:

1. **`formatLocalDate(date)`** - Formats Date to YYYY-MM-DD in local timezone (replaces `.toISOString().split('T')[0]`)
2. **`getTodayLocal()`** - Gets today's date in local timezone
3. **`parseLocalDate(dateStr)`** - Parses YYYY-MM-DD strings to Date objects at local midnight (safer than `new Date(dateStr)`)
4. **`addDays(dateStr, days)`** - Date arithmetic in local timezone

Then replaced all problematic patterns throughout the codebase.

## Changes

### Files Created
- `lib/date-utils.ts` - New timezone-safe utilities

### Files Modified (10 files)
- `lib/stats-utils.ts` - Fixed working day calculation
- `stores/habitStore.ts` - Fixed initial selected date
- `stores/calendarStore.ts` - Fixed weekend detection
- `components/DateSelector.tsx` - Fixed date navigation
- `components/Dashboard.tsx` - Fixed week calculation and date display
- `components/Settings.tsx` - Fixed date formatting
- `app/api/stats/habit/[id]/route.ts` - Fixed habit stats and fallback pattern
- `app/api/stats/batch/route.ts` - Fixed batch stats
- `app/api/stats/overview/route.ts` - Fixed overview stats and fallback pattern

### Summary
- ✅ 15+ instances of `.toISOString().split('T')[0]` replaced
- ✅ Fixed all `new Date(dateStr)` patterns that could cause timezone issues
- ✅ Removed remaining `.split('T')[0]` in fallback code
- ✅ Build passes with no errors
- ✅ All date operations now use local timezone consistently

## Testing

Recommended test scenarios:

1. **UTC+ Timezone Test (e.g., JST)**
   - Set system timezone to Asia/Tokyo
   - Test at 2:00 AM local time (when UTC is still previous day)
   - Verify dashboard shows correct date, not yesterday

2. **Date Navigation Test**
   - Click prev/next day buttons
   - Click "Today" button
   - Verify dates transition correctly at midnight

3. **Streak Calculation Test**
   - Complete habits for consecutive days
   - Verify streak counts correctly
   - Test at midnight boundary

4. **Week View Test**
   - Verify week range calculations are correct
   - Test on Sunday/Monday (week boundaries)

## Risk Assessment
**Low Risk:**
- Pure substitution with no logic changes
- No API contract changes (still uses YYYY-MM-DD format)
- No database schema changes
- Backward compatible
- Easy rollback (single commit revert)

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)